### PR TITLE
Open restaurants in in-app webview

### DIFF
--- a/app.tsx
+++ b/app.tsx
@@ -2,6 +2,7 @@ import { NavigationContainer } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import React from "react";
 import HomeScreen from "./screens/HomeScreen";
+import RestaurantWebView from "./screens/RestaurantWebView";
 
 const Stack = createNativeStackNavigator();
 
@@ -10,6 +11,11 @@ export default function App() {
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen name="Yarka Restaurants" component={HomeScreen} />
+        <Stack.Screen
+          name="RestaurantWebView"
+          component={RestaurantWebView}
+          options={({ route }) => ({ title: (route.params as { name: string }).name })}
+        />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/components/ui/RestaurantCard.tsx
+++ b/components/ui/RestaurantCard.tsx
@@ -1,5 +1,6 @@
 // components/ui/RestaurantCard.tsx
-import { Image, Linking, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { Image, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import { useNavigation } from "@react-navigation/native";
 
 type Props = {
   name: string;
@@ -10,8 +11,10 @@ type Props = {
 };
 
 export default function RestaurantCard({ name, description, url, image, isOpen }: Props) {
+  const navigation = useNavigation<any>();
+
   return (
-    <TouchableOpacity style={styles.card} onPress={() => Linking.openURL(url)}>
+    <TouchableOpacity style={styles.card} onPress={() => navigation.navigate("RestaurantWebView", { url, name })}>
       <Image source={{ uri: image }} style={styles.image} />
       <View style={styles.info}>
         <Text style={styles.name}>{name}</Text>

--- a/screens/RestaurantWebView.tsx
+++ b/screens/RestaurantWebView.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { StyleSheet } from "react-native";
+import { WebView } from "react-native-webview";
+import { useRoute } from "@react-navigation/native";
+
+export default function RestaurantWebView() {
+  const route = useRoute();
+  const { url } = route.params as { url: string };
+
+  return <WebView source={{ uri: url }} style={styles.webview} />;
+}
+
+const styles = StyleSheet.create({
+  webview: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
## Summary
- Navigate to a new RestaurantWebView screen when tapping a restaurant card
- Display restaurant webpages inside the app without showing the URL

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ee124bc44832099c31769e8eec372